### PR TITLE
Fix ExposeData issue with HediffComp_InvisibilityEngulfer

### DIFF
--- a/1.4/Source/VFED/Comps/CompInvisibilityEngulfer.cs
+++ b/1.4/Source/VFED/Comps/CompInvisibilityEngulfer.cs
@@ -79,6 +79,6 @@ public class HediffComp_InvisibilityEngulfer : HediffComp
     public override void CompExposeData()
     {
         base.CompExposeData();
-        Scribe_Values.Look(ref source, nameof(source));
+        Scribe_References.Look(ref source, nameof(source));
     }
 }


### PR DESCRIPTION
`HediffComp_InvisibilityEngulfer` is using `Scribe_Values` for a `Thing`, which causes an error when trying to save (not saving the value). After reloading the value will be null and (once invisibility ends) the cooldown won't be triggered.

The error reported by the game: `Using Scribe_Values with a Thing reference source. Use Scribe_References or Scribe_Deep instead.`

The fix was to simply replace `Scribe_Values` with `Scribe_References`.