### PR TITLE
Improvements to CompBoxRefuel

### DIFF
--- a/1.4/Patches/VanillaFurnitureExpandedSecurity.xml
+++ b/1.4/Patches/VanillaFurnitureExpandedSecurity.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Furniture Expanded - Security</li>
+		</mods>
+		<match Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="VFES_Turret_AutocannonDouble"]/comps</xpath>
+			<value>
+				<li Class="VFED.CompProperties_BoxRefuel">
+					<refuelWith>VFED_AmmoBox_Autocannon</refuelWith>
+					<!-- 2 to 1 conversion of steel to ammo -->
+					<refuelAmount>90</refuelAmount>
+				</li>
+			</value>
+		</match>
+	</Operation>
+</Patch>

--- a/1.4/Source/VFED/Comps/CompBoxRefuel.cs
+++ b/1.4/Source/VFED/Comps/CompBoxRefuel.cs
@@ -37,8 +37,13 @@ public class CompBoxRefuel : ThingComp
         for (var i = 0; i < checkThings.Count; i++)
             if (checkThings[i].def == Props.refuelWith)
             {
-                compRefuelable.Refuel(compRefuelable.Props.fuelCapacity / compRefuelable.Props.FuelMultiplierCurrentDifficulty);
+                var refuelAmount = Props.refuelAmount > 0 ? Props.refuelAmount : compRefuelable.Props.fuelCapacity;
+                compRefuelable.Refuel(refuelAmount / compRefuelable.Props.FuelMultiplierCurrentDifficulty);
                 checkThings[i].Destroy();
+
+                // Use the vanilla method that handles auto rebuilding and pass the only DestroyMode that allows it.
+                // Also don't use checkThings[i].Map, as it'll be null after the Destroy call.
+                ThingUtility.CheckAutoRebuildOnDestroyed(checkThings[i], DestroyMode.KillFinalize, parent.Map, checkThings[i].def);
                 break;
             }
     }
@@ -62,6 +67,7 @@ public class CompProperties_BoxRefuel : CompProperties
 {
     public bool mustUseBoxes;
     public ThingDef refuelWith;
+    public int refuelAmount = -1;
 
     public CompProperties_BoxRefuel() => compClass = typeof(CompBoxRefuel);
 


### PR DESCRIPTION
Changes/additions:
- Added `refuelAmount` to the props. If positive, it will determine how much the turret will be refueled by. Defaults to -1 if not set.
- Added box refuel for double autocannon turret from Vanilla Furniture Expanded - Security (if active). It will restore half its capacity (90 ammo, 2 to 1 steel to ammo rate).
- Ammo boxes will be automatically rebuilt when used. It uses the same method as vanilla rebuild method, so it'll follow the same rules (auto rebuild on, home area, research finished, player faction, etc.).