### PR TITLE
Disallow purchasing contraband with empty basket

### DIFF
--- a/1.5/Source/VFED/UI/DesertersUIUtility.cs
+++ b/1.5/Source/VFED/UI/DesertersUIUtility.cs
@@ -41,8 +41,9 @@ public static class DesertersUIUtility
 
     public static bool DoPurchaseButton(Rect inRect, string text, int intelCost, int criticalIntelCost, Dialog_DeserterNetwork parent)
     {
-        if (!parent.HasIntel(intelCost, criticalIntelCost)) GUI.color = Color.grey;
-        if (Widgets.ButtonText(inRect, text) && parent.TrySpendIntel(intelCost, criticalIntelCost))
+        var cartEmpty = ContrabandManager.ShoppingCart.NullOrEmpty();
+        if (!parent.HasIntel(intelCost, criticalIntelCost) || cartEmpty) GUI.color = Color.grey;
+        if (Widgets.ButtonText(inRect, text) && !cartEmpty && parent.TrySpendIntel(intelCost, criticalIntelCost))
         {
             SoundDefOf.ExecuteTrade.PlayOneShotOnCamera();
             GUI.color = Color.white;


### PR DESCRIPTION
If a basket is empty, the purchase button will be greyed-out and disabled. This should prevent spawning of unnecessary drop pods or spawning a dead drop quest when there's no items.